### PR TITLE
Improved readability and fixed minor grammar issues in dungeons.md

### DIFF
--- a/en/activities-and-challenges/dungeons.md
+++ b/en/activities-and-challenges/dungeons.md
@@ -1,16 +1,16 @@
 # Dungeons
 
-Dungeons in the game allow you to engage in combat for long periods without needing to interact directly, unlike battling enemies. They are also the main way to get recipes, which you need to craft the strongest items.
+Dungeons in the game allow you to engage in combat for long periods without needing to interact directly, unlike battling enemies. They are the primary source of recipes needed to craft the strongest items.
 
 The game has various dungeons, each with different difficulty levels. As a dungeon's level increases, so does its difficulty, making it harder to succeed.
 
-Each dungeon has multiple floors, shown in the action bar, representing the player's ongoing idle actions. Once all floors are cleared, the dungeon ends automatically, and you receive the rewards.
+Each dungeon has multiple floors displayed in the action bar, indicating the player's ongoing idle actions. Once all floors are cleared, the dungeon ends automatically, and you receive the rewards.
 
-Participating in dungeons requires a significant investment of both time and currency to obtain the best items. As dungeon levels increase, the costs in both gold and time also go up.
+Dungeons require a significant investment of time and currency to acquire the best items. As dungeon levels increase, the costs in both gold and time also go up.
 
 #### List of Dungeons
 
-| Dungeon | Level Required | Location | Cost  | Time To Complete |
+| Dungeon | Level Required | Location | Cost  | Completion Time |
 | ------- | -------------- | -------- | ----- | ---------------- |
 | __Millstone Mines__ | Lv. 3 | Bluebell Hollow | 300 | 15m |
 | __Vineyard Labyrinth__ | Lv. 10 | Bluebell Hollow | 1,200 | 15m |

--- a/en/activities-and-challenges/hunting-and-battling.md
+++ b/en/activities-and-challenges/hunting-and-battling.md
@@ -2,9 +2,9 @@
 
 ## Hunting
 
-Before you jump into combat, you'll first need to locate a group of enemies by going on a hunt. How long your hunt lasts depends on two things: your `Movement Speed` and your `Hunting Mastery`. The faster you move and the more skilled you are at hunting, the longer you'll be able to keep up the chase.
+Before you jump into combat, you'll first need to locate a group of enemies by going on a hunt. The duration of your hunt depends on two factors: `Movement Speed` and `Hunting Mastery`. The faster you move and the more skilled you are at hunting, the longer you'll be able to keep up the chase.
 
-The longest you can hunt is tied to your character’s maximum idle time. For example, if your character is marked as the "main character" and has an active membership, they can stay in action for up to **180** minutes.
+Your maximum hunting duration is determined by your character’s idle time. For example, if your character is marked as the "main character" and has an active membership, they can stay in action for up to **180** minutes.
 
 You can increase your `Movement Speed` with the help of [Pets](/wiki/activities-and-challenges/pets) and you can increase your `Hunting Mastery` by completing hunts.
 
@@ -17,7 +17,7 @@ For example, if you were hunting **200** enemies over **100** minutes and cancel
 You can restart a hunt at any time, and it will continue from where you left off. Any new enemies you hunt will be added to what you’ve already hunted. So, if you’ve already hunted **50** `Goblins` and start again, the new enemies will stack on top of those 50.
 
 #### Enemy Decay
-Enemies will flee over time if you're not fast enough to engage them in battle. The rate at which they run away depends entirely on your hunting level - the higher your hunting mastery, the fewer enemies will escape.
+Enemies gradually flee if you don’t engage them in battle quickly. The rate at which they run away depends entirely on your hunting level - the higher your hunting mastery, the fewer enemies will escape.
 
 The scale ranges from **25%** to **10%**. At Hunting Mastery level 1, **25%** of discovered enemies will flee every **3 hours**. At Hunting Mastery level 100, only **10%** will flee in the same timeframe.
 
@@ -27,11 +27,11 @@ The timer starts when the enemy is first discovered, and you’ll see a countdow
 
 - You can only hunt enemies that match your combat level. For example, if your combat level is **20**, the highest level enemies you can hunt are level **20**. Enemies above level **20** will not be hunted. So, if you try hunting in higher-level areas without the required combat level, you may end up with no enemies.
 - Since `v0.23.0`, pets can no longer hunt for enemies on behalf of your character. Only your characters can hunt.
-- Since `v0.23.5`, there are no limits to the number of enemies you can hunt. Instead, the slowly decay over time.
+- Since `v0.23.5`, there is no limit to the number of enemies you can hunt. Instead, they slowly decay over time.
 
 ## Battling
 
-Once you've located a mob, you can start a battle by selecting an enemy and clicking `Battle`. You may only select one enemy at a time to battle.
+After locating a mob, select an enemy and click `Battle` to begin. You can only battle one enemy at a time.
 
 #### Battle Mechanics
 
@@ -43,11 +43,11 @@ Here’s how it works: after selecting an enemy to battle, your character will k
 
 When a battle begins, the UI will show you the following key information, so you can track how well your character is performing during the fight:
 
-- Your characters hit chance
+- Your character’s hit chance
 - How much damage your character deals per hit
 - How much damage your character receives per hit
 - How many hits you need to defeat the enemy
-- The enemies hit chance
+- The enemy's hit chance
 - How many enemies you have already defeated according to the time that has elapsed
 - How many enemies you have left to defeat
 
@@ -59,18 +59,18 @@ Before starting a battle, you can choose various food items to take with you. Th
 
 For example, if your character has **100** HP and you bring **20** food items, each adding **10** HP, your total effective health becomes **300** HP `(100 + (20 * 10) = 300)`. With more effective health, you can take on more enemies without being defeated. If you bring enough food, you might even be able to fight all the way up to your character’s maximum idle time.
 
-If you end a battle early, any unused food will be returned to your inventory. The system will attempt to prioritise using the weakest food items first. For example, if you have 1x **500** HP food item and 100x **100** HP food items, it will try to use the **100** HP items before the **500** HP item. However, this may not always happen exactly like this, as it depends on the battle and when you choose to stop it.
+If you end a battle early, any unused food will be returned to your inventory. The system prioritizes using the weakest food items first. For example, if you have 1x **500** HP food item and 100x **100** HP food items, it will try to use the **100** HP items before the **500** HP item. However, this may not always happen exactly like this, as it depends on the battle and when you choose to stop it.
 
 #### Stance
 Stance lets you choose which stat you want to focus on when earning EXP rewards after defeating an enemy.
 
 Here are the five stances you can select:
 
-**Balanced**: Obtains EXP for every primary stat. for instance, if you get 20 EXP, then each stat will get 5 EXP.\
+**Balanced**: Distributes EXP evenly across all primary stats. For example, earning 20 EXP gives 5 EXP to each stat.\
 **Offensive**: Obtains EXP only for `Strength`.\
 **Defensive**: Obtain EXP only for `Defence`.\
 **Agile**: Obtains EXP only for `Speed`.\
-**Dexterous**: Obtains EXP only for `Dexterity`.
+**Dexterous**: Gains EXP only for `Dexterity`.
 
 You can choose your stance when you start a battle, but you can't change it once the battle begins. If you want to switch stances, you’ll need to end the current battle and start a new one.
 
@@ -98,5 +98,5 @@ This scaling approach is designed to avoid major imbalances in loot frequency. F
 - Taking a lot of food with you will increase your effective health, allowing you to battle for longer.
 - Improving your stats with better equipment means you can defeat enemies faster and with less damage taken. This also means you don't need to use as much food - saving additional time and money.
 - Using the `Balanced` stance may result in less EXP if it cannot be divided evenly. For instance, if you defeat an enemy and you obtain `25 EXP`, that means each stat will get `6 EXP` totalling at `24 EXP` and the remaining `1 EXP` will be lost.
-- There is a limit of __8 seconds__ seconds per enemy. It's not possible to defeat enemies quicker than __8 seconds__.
+- There is a limit of __8 seconds__ per enemy. It's not possible to defeat enemies quicker than __8 seconds__.
 - There is a minimum of _1 damage__ taken per battle. It's impossible to encounter a battle and leave unharmed.


### PR DESCRIPTION
**Introduction Section:**

- Original: “They are also the main way to get recipes, which you need to craft the strongest items.”
Fix: “They are the primary source of recipes needed to craft the strongest items.” (_More concise and clear._)

- Original: “Each dungeon has multiple floors, shown in the action bar, representing the player's ongoing idle actions.”
Fix: “Each dungeon has multiple floors displayed in the action bar, indicating the player's ongoing idle actions.” (_Improved readability._)

- Original: “Participating in dungeons requires a significant investment of both time and currency to obtain the best items.”
Fix: “Dungeons require a significant investment of time and currency to acquire the best items.” (_Avoids redundancy._)

**List of Dungeons Table:**

- "Time To Complete” → “Completion Time” (_Better wording for consistency with in-game terms._)